### PR TITLE
fix: コンソール出力の文字化けを修正 (#3)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,8 @@ class Program
 {
     static void Main(string[] args)
     {
+        // 文字エンコーディングを明示的に設定
+        Console.OutputEncoding = Encoding.UTF8;
         Console.WriteLine("こんにちは");
     }
 }


### PR DESCRIPTION
## 関連Issue
Closes #3

## 変更内容
- Console.OutputEncodingをUTF-8に明示的に設定
- Windows環境での日本語出力問題を解消

## 変更種別
- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング

## 原因と対応内容
Windows環境のコマンドプロンプトではデフォルトエンコーディングがShift_JISのため、UTF-8の文字列が正しく表示されなかった。
プログラム起動時にConsole.OutputEncodingをUTF-8に設定することで、明示的に出力エンコーディングを指定し解消。

## テスト結果
- [x] Windows 10 コマンドプロンプト
- [x] Windows 10 PowerShell
- [x] 他機能への影響なし